### PR TITLE
Add map-based storage as well as array-based storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,10 +337,10 @@ We then define all our citations in ```references.md``` like this:
 <!-- define_citation code="cit2" author="wikipedia.org" title="Venn Diagram" date="" location="" type="website" href="https://en.wikipedia.org/wiki/Venn_diagram" -->
 ```
 
-The plugin will dynamically create the citations map as the ```book.variables.citations``` variable. We can then index it in markdown pages, for example ```reflections.md```:
+The plugin will dynamically create the citations map as the ```book.citations``` variable. We can then index it in markdown pages, for example ```reflections.md```:
 
 ```markdown
-The so-called "vescica piscis" {{book.variables.citations["cit1"]}} can be seen as a part of a Venn diagram {{book.variables.citations["cit2"]}} ...
+The so-called "vescica piscis" {{book.citations["cit1"]}} can be seen as a part of a Venn diagram {{book.citations["cit2"]}} ...
 ```
 
 The links and the citation text can then be styled through ```css``` in a way similar to the previous example.

--- a/README.md
+++ b/README.md
@@ -299,3 +299,46 @@ Screenshot of output:
 ![Footnotes](https://github.com/markomanninen/gitbook-plugin-regexplace/raw/master/footnotes.png)
 
 With ```gitbook-plugin-regexplace``` configuration patterns, substitutes, markdown templates and stylesheet you can manage a pretty detailed citation/footnote system on a GitBook project.
+
+
+Data generation and lookup
+-----
+
+Gitbook offers the possibility of using variables in ```book.json``` so that data can be dynamically looked up in Markdown files. As a silly example, a variable can be used to hold the name of a character in a story, so that every time the author changes their mind about the name it can be replaced in just one place.
+
+However, variables can be much more powerful than that. A map variable can hold a lot of data that could be looked up at different points in the book, using unique keys as indices. This would be really useful, if it wasn't for the fact that if you have a lot of data your ```book.json``` becomes very large.
+
+Ideally, you would like to list your data items in a separate file, or maybe more than one file. Because ```gitbook-plugin-regexplace``` allows you to store regular expression matches in a variable, you can construct your map from data contained in Markdown files. All you need to do is to have a ```key``` parameter in the ```store``` section, and instead of storing the data in an array the plugin will treat the variable as a map, using the ```key``` to index it.
+
+For example, let's consider an alternative way of doing citations. We are going to define all our citations in a Markdown file, which will be compiled with the full data for the citations; we will then use a dynamically created variable in other Markdown files to create the links to the citations.
+
+Here is the pattern in ```book.json```:
+
+```json
+{
+    "pattern": "<!-- define_citation code=\"(.*?)\" author=\"(.*?)\" title=\"(.*?)\" date=\"(.*?)\" location=\"(.*?)\" type=\"(.*?)\"(.*?) -->",
+    "flags": "g",
+    "substitute": "<span><a id=\"ref_$1\">$1</a></span> <span>$2:</span> <span><a$7>$3</a></span> <span>$4</span> <span>$5</span>",
+    "store": {
+        "key": "$1",
+        "substitute": "<sup><a id=\"cite_$1\" href=\"references.html#ref_$1\" title=\"$2: $3 $4\" type=\"$6\">$1</a></sup>",
+        "variable_name": "citations"
+    }
+}
+```
+
+Note the ```code=``` attribute in the HTML comment. This will be used as the map key because of the ```key: "$1"``` property of the ```store``` section. Also note that, contrary to the previous use case, we are now substituting the full definition of the citation, and storing the link to it.
+
+We then define all our citations in ```references.md``` like this:
+
+```markdown
+<!-- define_citation code="cit1" author="wikipedia.org" title="Vesica Piscis" date="" location="" type="website" href="http://en.wikipedia.org/wiki/Vesica_piscis" -->
+
+<!-- define_citation code="cit2" author="wikipedia.org" title="Venn Diagram" date="" location="" type="website" href="https://en.wikipedia.org/wiki/Venn_diagram" -->
+```
+
+The plugin will dynamically create the citations map as the ```book.variables.citations``` variable. We can then index it in markdown pages, for example ```reflections.md```:
+
+```markdown
+The so-called "vescica piscis" {{book.variables.citations["cit1"]}} can be seen as a part of a Venn diagram {{book.variables.citations["cit2"]}} ...
+```

--- a/README.md
+++ b/README.md
@@ -342,3 +342,5 @@ The plugin will dynamically create the citations map as the ```book.variables.ci
 ```markdown
 The so-called "vescica piscis" {{book.variables.citations["cit1"]}} can be seen as a part of a Venn diagram {{book.variables.citations["cit2"]}} ...
 ```
+
+The links and the citation text can then be styled through ```css``` in a way similar to the previous example.

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ var collectStore = function(page, that, pageHook) {
           if (!pageHook && sub2) {
             if (pattern.decode) sub2 = decodeHtmlEntities(sub2);
             if (pattern.store.lower) sub2 = sub2.toLowerCase();
-            // Storage is either map-based or array-based
+            // Storage can be map-based with a key or array-based
             if(pattern.store.key) {
               if (!pattern.store.unique || !variables[pattern.store.variable_name][subkey]) {
                 variables[pattern.store.variable_name][subkey] = sub2;

--- a/index.js
+++ b/index.js
@@ -32,8 +32,10 @@ var collectStore = function(page, that, pageHook) {
   patterns.forEach(function (pattern) {
 
       var variables = that.config.get(vars);
-      if (pattern.store && pattern.store.variable_name && !variables[pattern.store.variable_name])
+      if (pattern.store && pattern.store.variable_name && !pattern.store.key && !variables[pattern.store.variable_name])
         variables[pattern.store.variable_name] = [];
+      if (pattern.store && pattern.store.variable_name && pattern.store.key && !variables[pattern.store.variable_name])
+        variables[pattern.store.variable_name] = {};
 
       var match;
       var i = 0;
@@ -42,18 +44,24 @@ var collectStore = function(page, that, pageHook) {
       // get matches from content
       while (match = regex.exec(content)) {
           i += 1;
-          var sub, sub2;
+          var sub, sub2, subkey;
           // use temporary storage if configured so
           if (!pageHook && pattern.store && pattern.store.substitute) {
             sub2 = pattern.store.substitute.replace(regex_index, i);
             sub2 = sub2.replace(regex_page_level, level);
             sub2 = sub2.replace(regex_page_path, path);
           }
+          // prepare the storage key if configured so
+          if (!pageHook && pattern.store && pattern.store.key) {
+            subkey = pattern.store.key.replace(regex_index, i);
+            subkey = subkey.replace(regex_page_level, level);
+            subkey = subkey.replace(regex_page_path, path);
+          }
           // set _INDEX_, _PAGE_LEVEL_ and _PAGE_PATH_ templates
           sub = pattern.sub.replace(regex_index, i);
           sub = sub.replace(regex_page_level, level);
           sub = sub.replace(regex_page_path, path);
-          // find $n replacement parts from substitute string
+          // find $n replacement parts from substitute string, on all substitutions
           for (var c = 1; c < match.length; c++) {
             var $ = '\$'+c;
             var count = sub.split($).length;
@@ -66,13 +74,26 @@ var collectStore = function(page, that, pageHook) {
                 sub2 = sub2.replace($, match[c]);
               }
             }
+            if (!pageHook && subkey) {
+              count = subkey.split($).length;
+              for (d = 0; d < count; d++) {
+                subkey = subkey.replace($, match[c]);
+              }
+            }
           }
           // if storage is used
           if (!pageHook && sub2) {
             if (pattern.decode) sub2 = decodeHtmlEntities(sub2);
             if (pattern.store.lower) sub2 = sub2.toLowerCase();
-            if (!pattern.store.unique || variables[pattern.store.variable_name].indexOf(sub2) < 0) {
-              variables[pattern.store.variable_name].push(sub2);
+            // Storage is either map-based or array-based
+            if(pattern.store.key) {
+              if (!pattern.store.unique || !variables[pattern.store.variable_name][subkey]) {
+                variables[pattern.store.variable_name][subkey] = sub2;
+              }
+            } else {
+              if (!pattern.store.unique || variables[pattern.store.variable_name].indexOf(sub2) < 0) {
+                variables[pattern.store.variable_name].push(sub2);
+              }
             }
           }
           // repeatingly replace content


### PR DESCRIPTION
Hi markomanninen,

currently the storage functionality in the plugin creates an array. This is very useful in many cases, however if you then want to use only one of the elements you can only search by index. It would be nice if each stored value could optionally be indexed by a "key" which could be a portion of the regexp (one of the groups, typically).

For example, if I had a regexp pattern like this:

```
<!-- my_regex code="(.*?)" value="(.*?)" -->
```

And I wrote something like this in my markdown:

```
<!-- my_regex code="my_code" value="blah blah blah" -->
```

Then I might want to store the matched text in a map keyed by the "code", so I can retrieve it with something like:

```
{{ book.my_variable["my_code"] }}
```

And this would print "blah blah blah".

My pull request adds this feature.

Basically, you can now provide a `key` property under `store`. If you do, the variable where the matches are stored is treated as a map rather than an array. The `key` string is processed (supporting `_INDEX_`, `_PAGE_LEVEL_`, the regexp groups, and so on) and the result is used as the key in the map. The value is instead the usual `store.substitute`.

This makes it possible to have a sort of "database" in one of your markdown files, and extract individual rows from the "database" in other markdown files by just indexing a variable. It's pretty neat.

I've made this change locally to your plugin for one of my gitbooks, and I'm very happy it works as intended.

I hope you like it too; if so, feel free to accept the pull request.
